### PR TITLE
Upgrade to Spring Boot 3.x and JRE 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ the License.
     <parent>
         <groupId>com.wilddiary</groupId>
         <artifactId>spring-base-starter</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <relativePath />
     </parent>
     <artifactId>spring-repository-template</artifactId>


### PR DESCRIPTION
Upgrading to spring-base-starter 1.1.0 to upgrade to JRE 17 and Spring Boot 3.x